### PR TITLE
Add support for arm build, non-DMD builds, fix gyp dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
 endif
 EXAMPLES_FLAGS=-Isrc/ $(DFLAGS)
 lib_uv=../out/uv.a
-DC=dmd
+DC ?=dmd
 
 
 build: duv.lib

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ uv: deps/uv/build
 deps/uv/build:
 	git submodule update --init --recursive
 	cd deps/uv; mkdir -p build
-	git clone https://git.chromium.org/external/gyp.git deps/uv/build/gyp
+	git clone https://chromium.googlesource.com/external/gyp deps/uv/build/gyp
 	cd deps/uv ; ./gyp_uv.py -f make
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,5 @@ deps/uv/build:
 
 clean:
 		rm -rf out
-		rm -rf deps/*
+		rm -rf deps/build
+		rm -rf deps/out

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "targetType": "sourceLibrary",
     "lflags-osx": ["-framework", "CoreServices"],
     "sourceFiles-osx-x86_64": ["dub/bin/uv.bridged-osx-x86_64.a"],
-    "sourceFiles-linux-x86_64": ["dub/bin/uv.bridged-linux-x86_64.a"]
+    "sourceFiles-linux-x86_64": ["dub/bin/uv.bridged-linux-x86_64.a"],
+    "sourceFiles-linux-arm": ["dub/bin/uv.bridged-linux-armv5tel.a"]
 }
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "importPaths": ["lib"],
     "targetType": "sourceLibrary",
     "lflags-osx": ["-framework", "CoreServices"],
+    "sourceFiles": ["out/uv.bridged.a"],
     "sourceFiles-osx-x86_64": ["dub/bin/uv.bridged-osx-x86_64.a"],
-    "sourceFiles-linux-x86_64": ["dub/bin/uv.bridged-linux-x86_64.a"],
-    "sourceFiles-linux-arm": ["dub/bin/uv.bridged-linux-armv5tel.a"]
+    "sourceFiles-linux-x86_64": ["out/duv.c.o"],
+    "sourceFiles-linux-arm": ["out/duv.c.o"]
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "uv",
     "description": "D bindings for libuv",
+    "copyright": "Copyright © 2013-2014, Heapsource.com, 2014-2016 IoTone, Inc.",
     "license": "MIT",
     "sourcePaths": ["lib"],
     "importPaths": ["lib"],
@@ -9,6 +10,9 @@
     "sourceFiles": ["out/uv.bridged.a"],
     "sourceFiles-osx-x86_64": ["dub/bin/uv.bridged-osx-x86_64.a"],
     "sourceFiles-linux-x86_64": ["out/duv.c.o"],
-    "sourceFiles-linux-arm": ["out/duv.c.o"]
+    "sourceFiles-linux-armv5tel": ["dub/bin/http-parser-linux-armv5tel.d.c.o", "dub/bin/http-parser-linux-armv5tel.o"],
+    "sourceFiles-linux-armv7l": ["dub/bin/http-parser-linux-armv7l.d.c.o", "dub/bin/http-parser-linux-armv7l.o"]
+
+
 }
 


### PR DESCRIPTION
Since we don't have DMD on arm, we must use gdc.  By passing DC into the environment when calling make, we can specify gdmd.  Otherwise, default to DMD.  We only need to expose the bridge library, and linking should go smoothly for any projects depending on this.   Clean is less destructive.

Also, gyp dependency was broken because it moved to a new location, so fix that.
